### PR TITLE
fix: correct export syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { defaultValueRule } from './default-value/default-value';
 
-export default {
+export = {
   rules: {
     'default-value': defaultValueRule,
   },


### PR DESCRIPTION
## Motivation
ESLint wants the index.js of plugins to look like `module.exports = { ... }` instead of `exports.default = { ... }`.

This change makes that happen.