### PR TITLE
feat: prevent nested interpolation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,6 @@ module.exports = {
 #### `default-value`
 
 - `translateFunctionNames`: an array of translation function names to validate. Default is `['t']`
-- `allowKeyOnly`: whether to allow e.g. `t('just-the-key')`
+- `allowKeyOnly`: whether to allow e.g. `t('just-the-key')`. Default is `false`.
+- `allowNestingInterpolation`: Whether to allow e.g. `{ defaultValue: 'some string $t(interpolated)' }`. Default is `false`.
+- `nestingPrefix`: Used when `allowNestingInterpolation` is `false` to identify interpolated variables. Default is `"$t(`.

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ module.exports = {
 - `translateFunctionNames`: an array of translation function names to validate. Default is `['t']`
 - `allowKeyOnly`: whether to allow e.g. `t('just-the-key')`. Default is `false`.
 - `allowNestingInterpolation`: Whether to allow e.g. `{ defaultValue: 'some string $t(interpolated)' }`. Default is `false`.
-- `nestingPrefix`: Used when `allowNestingInterpolation` is `false` to identify interpolated variables. Default is `"$t(`.
+- `nestingPrefix`: Used when `allowNestingInterpolation` is `false` to identify interpolated variables. Default is `"$t("`.

--- a/src/default-value/default-value.test.ts
+++ b/src/default-value/default-value.test.ts
@@ -46,6 +46,27 @@ tester.run('default-value', defaultValueRule, {
         someOtherFunction()
       `,
     },
+    {
+      code: `
+        t('key', {
+          defaultValue: 'some interpolated $t(var)'
+        })
+      `,
+      options: [{ allowNestingInterpolation: true }],
+    },
+    {
+      code: `
+        t('key', {
+          defaultValue: 'some interpolated $nest(var)'
+        })
+      `,
+      options: [
+        {
+          allowNestingInterpolation: true,
+          nestingPrefix: '$nest(',
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -99,6 +120,27 @@ tester.run('default-value', defaultValueRule, {
       `,
       options: [{ translateFunctionNames: ['translate', 't'] }],
       errors: [Errors.missingVariable('long'), Errors.missingVariable('short')],
+    },
+    {
+      code: `
+        t('key', {
+          defaultValue: 'some interpolated $t(var)'
+        })
+      `,
+      errors: [Errors.referenceInterpolation],
+    },
+    {
+      code: `
+        t('key', {
+          defaultValue: 'some interpolated $nest(var)'
+        })
+      `,
+      options: [
+        {
+          nestingPrefix: '$nest(',
+        },
+      ],
+      errors: [Errors.referenceInterpolation],
     },
   ],
 });

--- a/src/default-value/default-value.ts
+++ b/src/default-value/default-value.ts
@@ -9,7 +9,8 @@ export const Errors = {
     'Translate function defaultValue must a string property on the second argument',
   missingVariable: (named: string) =>
     `Missing "${named}" in translate variables`,
-  referenceInterpolation: `Detected an interpolated variable. Use a static string instead.`,
+  referenceInterpolation:
+    'Detected an interpolated variable. Use a static string instead.',
 };
 
 const findDefaultValueOnObject = (node: ObjectExpression) => {


### PR DESCRIPTION
## Motivation
In working with translators, we received feedback that using i18next's "nested interpolation" is confusing and at times problematic.

Example:
```
// en.json
{
  "session": "Session",
  "individualSession: "1 on 1 $t(session)"
}
```

This causes confusion + extra work for translators (who typically move string-by-string when translating), and also causes problems in some languages. For example, `1 on 1 Session` can be a single word in German, so the German translator cannot translate the string well and maintain the interpolation.

Duplication of the term via a static string is preferable, according to translators. So, implementing automation to protect against these interpolations entering our strings.